### PR TITLE
Update main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 
-#include "alert.h"coin
+#include "alert.h"
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "db.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -977,7 +977,7 @@ int64_t GetProofOfWorkReward(int64_t nHeight, int64_t nFees)
 // miner's coin stake reward based on coin age spent (coin-days)
 int64_t GetProofOfStakeReward(int64_t nCoinAge, int64_t nFees)
 {
-    int64_t nSubsidy = nCoinAge * COIN_YEAR_REWARD * 33 / (365 * 33 + 8);
+    int64_t nSubsidy = COIN_YEAR_REWARD * 33 / (365 * 33 + 8) * nCoinAge;  //fixes overflow at 38.81million nCoinAge with reduced accuracy....won't match old code exactly unless .0 is added to a number to force floatingpoint... still debating... 
     if(nBestHeight > 525600) // ~3 Years
     {
         nSubsidy = nCoinAge * 0.1 * 33 / (365 * 33 + 8); // Semi-Hardcap (0.01%)


### PR DESCRIPTION
Fixes overflow after 38.81million nCoinAge but with reduced accuracy....won't match old code exactly unless .0 is added to a number to force floatingpoint calcs (retains accuracy with no overflow problem over 100billion nCoinAge as the returned value is well within int64 limits)... still debating...